### PR TITLE
Rename String class due to 'String' being a reserved word in PHP7

### DIFF
--- a/src/Formats/PlainString.php
+++ b/src/Formats/PlainString.php
@@ -5,7 +5,7 @@ namespace MysqlUuid\Formats;
 /**
  * The traditional UUID string format
  */
-class String implements Format
+class PlainString implements Format
 {
     const FORMAT = '/[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}/i';
 

--- a/src/Formats/ReorderedString.php
+++ b/src/Formats/ReorderedString.php
@@ -8,7 +8,7 @@ namespace MysqlUuid\Formats;
  * To retain the 4,2,2,2,6 byte separators, we have to split the node field when
  * we move it, and combine the time_mid and time_low fields.
  */
-class ReorderedString extends String
+class ReorderedString extends PlainString
 {
     /**
      * @inheritDoc

--- a/src/Uuid.php
+++ b/src/Uuid.php
@@ -4,7 +4,7 @@ namespace MysqlUuid;
 
 use InvalidArgumentException;
 use MysqlUuid\Formats\Format;
-use MysqlUuid\Formats\String;
+use MysqlUuid\Formats\PlainString;
 
 /**
  * MySQL UUID format utilities
@@ -39,7 +39,7 @@ class Uuid
         if ($format) {
             $this->format = $format;
         } else {
-            $this->format = new String();
+            $this->format = new PlainString();
         }
     }
 

--- a/test/MysqlUuid/ConvertTest.php
+++ b/test/MysqlUuid/ConvertTest.php
@@ -6,7 +6,7 @@ use MysqlUuid\Formats\Binary;
 use MysqlUuid\Formats\Format;
 use MysqlUuid\Formats\Hex;
 use MysqlUuid\Formats\ReorderedString;
-use MysqlUuid\Formats\String;
+use MysqlUuid\Formats\PlainString;
 use MysqlUuid\Test\BaseTest;
 
 class ConvertTest extends BaseTest
@@ -62,8 +62,8 @@ class ConvertTest extends BaseTest
     protected function getFormat($format)
     {
         switch ($format) {
-            case 'string':
-                return new String();
+            case 'plain':
+                return new PlainString();
             case 'reordered':
                 return new ReorderedString();
             case 'binary':
@@ -77,7 +77,7 @@ class ConvertTest extends BaseTest
     {
         return [
             [
-                'from'  => 'string',
+                'from'  => 'plain',
                 'to'    => 'reordered',
                 'cases' => [
                     'b8e2adff-0331-11e4-9583-080027f3add4' => '080027f3-add4-11e4-9583-0331b8e2adff',
@@ -85,7 +85,7 @@ class ConvertTest extends BaseTest
                 ],
             ],
             [
-                'from'  => 'string',
+                'from'  => 'plain',
                 'to'    => 'hex',
                 'cases' => [
                     'b8e2adff-0331-11e4-9583-080027f3add4' => 'b8e2adff033111e49583080027f3add4',
@@ -93,7 +93,7 @@ class ConvertTest extends BaseTest
                 ],
             ],
             [
-                'from'  => 'string',
+                'from'  => 'plain',
                 'to'    => 'binary',
                 'cases' => [
                     'b8e2adff-0331-11e4-9583-080027f3add4' => "\x08\x00\x27\xf3\xad\xd4\x95\x83\x11\xe4\x03\x31\xb8\xe2\xad\xff",

--- a/test/MysqlUuid/Formats/PlainStringTest.php
+++ b/test/MysqlUuid/Formats/PlainStringTest.php
@@ -2,14 +2,14 @@
 
 namespace MysqlUuid\Formats;
 
-class StringTest extends FormatTest
+class PlainStringTest extends FormatTest
 {
     /**
      * @return Format
      */
     protected function getSut()
     {
-        return new String();
+        return new PlainString();
     }
 
     protected function good()

--- a/test/MysqlUuid/UuidTest.php
+++ b/test/MysqlUuid/UuidTest.php
@@ -2,7 +2,7 @@
 
 namespace MysqlUuid;
 
-use MysqlUuid\Formats\String;
+use MysqlUuid\Formats\PlainString;
 use MysqlUuid\Test\BaseTest;
 
 class UuidTest extends BaseTest
@@ -30,7 +30,7 @@ class UuidTest extends BaseTest
             ->will($this->returnValue(null));
 
         $uuid = new Uuid('b8fc7a3e-0331-11e4-9583-080027f3add4', $format);
-        $uuid->toFormat(new String());
+        $uuid->toFormat(new PlainString());
     }
 
     public function testFieldCrud()
@@ -42,6 +42,6 @@ class UuidTest extends BaseTest
 
         $uuid->setField('clock_seq', 'ffff');
 
-        $this->assertEquals($uuid->toFormat(new String()), 'b8fc7a3e-0331-11e4-ffff-080027f3add4');
+        $this->assertEquals($uuid->toFormat(new PlainString()), 'b8fc7a3e-0331-11e4-ffff-080027f3add4');
     }
 }


### PR DESCRIPTION
Right now library uses String class which is a reserved word in PHP7.
Changed name of the class to PlainString